### PR TITLE
🐛  Fix missing headers errors when integrating via SPM and Tuist

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,12 +40,12 @@ let package = Package(
   dependencies: [
     // Dependencies declare other packages that this package depends on.
     .package(
-      url: "https://github.com/bourdakos1/abseil-cpp-SwiftPM.git",
-      branch: "cxx17-test"
+      url: "https://github.com/monzo/abseil-cpp-SwiftPM.git",
+      exact: "0.20240902.0"
     ),
     .package(
-      url: "https://github.com/firebase/boringssl-SwiftPM.git",
-      "0.7.1"..<"0.8.0"
+      url: "https://github.com/monzo/boringssl-SwiftPM.git",
+      exact: "0.7.3"
     ),
   ],
   targets: [
@@ -241,7 +241,10 @@ let package = Package(
         "json/wsjcpp.yml",
       ],
       sources: ["EmptySwiftPackageManagerFile.cpp"],
-      publicHeadersPath: "json/include"
+      publicHeadersPath: "json/include",
+      cxxSettings: [
+        .headerSearchPath("json/include")
+      ]
     ),
     .target(
       name: "protobuf",

--- a/connections/swift/NearbyCoreAdapter/Sources/Public/NearbyCoreAdapter/NearbyCoreAdapter.h
+++ b/connections/swift/NearbyCoreAdapter/Sources/Public/NearbyCoreAdapter/NearbyCoreAdapter.h
@@ -19,6 +19,7 @@
 #import "GNCDiscoveryDelegate.h"
 #import "GNCDiscoveryOptions.h"
 #import "GNCError.h"
+#import "GNCException.h"
 #import "GNCFlags.h"
 #import "GNCPayload.h"
 #import "GNCPayloadDelegate.h"


### PR DESCRIPTION
## Summary

Fixes 2 build issues when integrating the latest `main` via SPM (see attached screenshot):
- Missing `GNCException.h` in umbrella header
- Missing `nlohmann` headers (`cxxSettings` fix inspiration from [here](https://forums.swift.org/t/spm-wrapped-c-dependencies-hpp-header-file-not-found/57823))
- Fixes `moduleAliases` so this package builds in conjunction with other packages that also depend on `openssl_grpc` like Firebase. [According to Apple docs](https://developer.apple.com/documentation/packagedescription/package/dependency/modulealiases): `The key is an original target name and the value is a new unique name mapped to the name of the .swiftmodule binary.` 

![Screenshot 2024-08-23 at 08 49 15](https://github.com/user-attachments/assets/88e4854f-8ae6-4edc-8817-fcfd5da862d1)

## How did you test this change?

- Xcode 15.1
- macOS 14.6.1
- SPM integration via [Tuist](https://github.com/tuist/tuist) 4.24.0, also tested via regular Xcode SPM integration
