### PR TITLE
🐛 Fix alias reference

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -187,9 +187,7 @@ let package = Package(
       dependencies: [
         "protobuf",
         .product(name: "AbseilCXX17", package: "abseil-cpp-SwiftPM"),
-        .product(
-          name: "openssl_grpc", package: "boringssl-SwiftPM",
-          moduleAliases: ["NearbySSL": "openssl_grpc"]),
+        .product(name: "NearbySSL", package: "boringssl-SwiftPM"),
       ],
       path: "third_party/ukey2",
       exclude: [


### PR DESCRIPTION
Forgot to rename the package and use the alias in the previous PR.